### PR TITLE
fix: corrupt ui when the same content is repeated multiple times

### DIFF
--- a/src/components/noteList/notePreview.tsx
+++ b/src/components/noteList/notePreview.tsx
@@ -44,16 +44,19 @@ export default function NotePreview({
 			</span>
 			<hr className="divider" />
 			<div>
+				{/* FIXME: the 'keys' with index causes too much remounts
+						This was added so that same line repeating will not cause corrupted UI
+				 */}
 				{getIsEmptyDelta(parsedData) ? (
 					<div style={{ marginTop: '1em' }}>Click 'Edit' to add content.</div>
 				) : (
 					parsedData.map((lineData, dataIndex) => {
 						if (lineData.type === 'todo') {
 							return (
-								<div key={JSON.stringify(lineData.data)}>
+								<div key={`${dataIndex}${JSON.stringify(lineData.data)}`}>
 									{lineData.data.map((todo, todoIndex) => (
 										<TodoListItem
-											key={todo.text}
+											key={`${todoIndex}${todo.text}`}
 											{...todo}
 											dataIndex={dataIndex}
 											todoIndex={todoIndex}
@@ -63,10 +66,10 @@ export default function NotePreview({
 								</div>
 							);
 						} else if (lineData.data === '') {
-							return <br />;
+							return <br key={dataIndex} />;
 						}
 
-						return <p key={lineData.data}>{lineData.data}</p>;
+						return <p key={`${dataIndex}${lineData.data}`}>{lineData.data}</p>;
 					})
 				)}
 			</div>

--- a/src/utils/delta.ts
+++ b/src/utils/delta.ts
@@ -51,6 +51,7 @@ export function getTextFromDelta(delta: DeltaData[]) {
 	}
 
 	const deltaAsString = delta.reduce((acc, lineData, lineIndex) => {
+		const lineSeparator = lineIndex > 0? '\n': '';
 		if (lineData.type === 'todo') {
 			const todolistAsString = lineData.data.reduce(
 				(innerAcc, todo, todoIndex) =>
@@ -59,9 +60,9 @@ export function getTextFromDelta(delta: DeltaData[]) {
 						: innerAcc,
 				''
 			);
-			acc += lineIndex > 0? '\n': '' + todolistAsString;
+			acc += lineSeparator + todolistAsString;
 		} else {
-			acc += lineIndex > 0? '\n': '' + lineData.data;
+			acc += lineSeparator + lineData.data;
 		}
 
 		return acc;


### PR DESCRIPTION
when todos with same text exist, it will mess up the list keys.

Fixed for now by adding array index to keys.